### PR TITLE
Integration optimality principle in metta

### DIFF
--- a/an_infotheoretic_approach/integration.metta
+++ b/an_infotheoretic_approach/integration.metta
@@ -1,0 +1,77 @@
+! (import! &self libs)
+! (import! &self utils:list-op-utils)
+
+
+(= (check-against-predefined-list $item $item2 $terms_antonymity $list)
+    (if (== (size-atom $list) 0 )
+        0
+        (if (or 
+        (== ($item $item2) (car-atom $list)) 
+        (or 
+            (== ($item2 $item) (car-atom $list)) 
+            $terms_antonymity
+        )
+            )    1 ; Item found
+            (check-against-predefined-list $item $item2 $terms_antonymity (cdr-atom $list)) ; Recurse on the rest of the list
+        )
+    )
+)
+
+(= (count-trues-from-head-with-tail $head $tail_list $predefined-conflicts)
+  (if (< (size-atom $tail_list) 1)
+        0 
+        (let* (
+                ($current_tail_element (car-atom $tail_list))
+                ($remaining_tail (cdr-atom $tail_list))
+                ($current_add (check-against-predefined-list $head $current_tail_element (are_terms_antonyms $head $current_tail_element) $predefined-conflicts))
+                ($rest_add (count-trues-from-head-with-tail $head $remaining_tail $predefined-conflicts))
+            )
+            (+ $current_add $rest_add)
+        )
+    )
+)
+(= (conflict-check-loop $items $predefined-conflicts)
+  (if (< (size-atom $items) 2)
+      0
+      (let* (
+          ($head (car-atom $items))
+          ($tail (cdr-atom $items))
+          ($head_related_trues (count-trues-from-head-with-tail $head $tail $predefined-conflicts))
+          ($tail_related_trues (conflict-check-loop $tail $predefined-conflicts))
+        )
+        (+ $head_related_trues $tail_related_trues)
+      )
+  )
+)
+
+(= (properties-list (Blend $blend_name $properties $relations)) (
+    let $prop_list $properties (cdr-atom $prop_list)
+    )
+)
+
+(= (integration_op $blend )
+    (let*(
+        ($prop-list (properties-list $blend))
+        ($prop_names (map-atom $prop-list $x (car-atom $x)))
+        ($conflicts (conflict-check-loop $prop_names (predefined-conflicts)))
+        ($conflict_ratio (/ $conflicts (pow-math (size-atom $prop_names) 0.5)))
+    )
+        (
+            max-atom (0.0 (- 1.0 $conflict_ratio))
+        )
+    )
+)
+
+
+(= (predefined-conflicts)
+    ((hot cold) (liquid solid) (alive dead) (floats metald) (floats sinks) (on off) (open close) (true false) (win lose))
+)
+
+(= (amphibious_vehicle)
+    (Blend amphibious_vehicle 
+    (Properties  (metal (car)) (floats (boat)) (waterproof))
+    (Relations (UsedFor (transportation 1.0) (Short_HasPart (engine 0.8))))
+    )
+)
+
+! (integration_op (amphibious_vehicle))

--- a/an_infotheoretic_approach/libs/agents/optimality_principles/main/data_sources/conceptnet_adapter.py
+++ b/an_infotheoretic_approach/libs/agents/optimality_principles/main/data_sources/conceptnet_adapter.py
@@ -2,6 +2,7 @@ import requests
 import json
 from urllib.parse import quote
 from functools import lru_cache
+from hyperon import *
 
 class ConceptNetAdapter:
     BASE_URL = "http://api.conceptnet.io"
@@ -41,6 +42,9 @@ class ConceptNetAdapter:
         edges = self.get_edges(term1, "Antonym")
         antonym_terms = {edge["end"]["label"].lower() for edge in edges if "end" in edge}
         return term2.lower() in antonym_terms
+
+    def are_terms_antonyms(self, metta: MeTTa, *args):
+        return [ValueAtom(self.are_antonyms(str(args[0]), str(args[1])))]
 
     def is_related(self, term1, term2, rel_type=None):
         """Check if term1 has a specified relationship to term2."""

--- a/an_infotheoretic_approach/libs/main.py
+++ b/an_infotheoretic_approach/libs/main.py
@@ -2,6 +2,7 @@ import os
 from hyperon import *
 from hyperon.ext import register_atoms
 from .agents import *
+from .agents.optimality_principles.main.data_sources.conceptnet_adapter import ConceptNetAdapter
 
 
 # Define networks and their corresponding function names
@@ -37,6 +38,14 @@ def grounded_atoms(metta):
                 [AtomType.ATOM, AtomType.ATOM, "Expression"],
                 unwrap=False
             )
+
+    conceptnet = ConceptNetAdapter(True)
+    registered_operations["are_terms_antonyms"] = OperationAtom(
+        "are_terms_antonyms",
+        lambda *args: conceptnet.are_terms_antonyms(metta, *args),
+        [AtomType.ATOM, AtomType.ATOM, AtomType.ATOM],
+        unwrap=False
+    )
 
     return registered_operations
 


### PR DESCRIPTION
## Conflict Ratio Evaluation - Integration optimality principle

### Summary

This PR implements logic to evaluate the **conflict ratio** between properties of a blended concept using predefined antonym pairs and dynamic antonym check from conceptnet.

### Features

* `predefined-conflicts`: Static list of known conflicting property pairs.
* `are_terms_antonyms`: Grounded atom to support conceptnet antonym evaluation.
* `check-against-predefined-list`: Recursively checks for direct or antonym-based conflicts.
* `count-trues-from-head-with-tail`: Counts conflicts between a head item and each item in a tail list.
* `conflict-check-loop`: Computes total conflicts across all property combinations.
* `properties-list`: Extracts property list from a `Blend`.
* `integration_op`: Computes `conflict_ratio` and returns `max(0.0, 1 - ratio)` as an integration score.

### Example

Running:

```metta
metta integration.metta
```

Returns a score based on internal property conflicts of the `amphibious_vehicle` blend.

### Notes

* Handles both predefined and antonym-based conflicts via structured logic.
* This integration optimality score is pluggable on info-theoretic.metta.
* are_terms_antonyms grounded atom added tot get the antonymity of terms from conceptnet
* **Since this is my first MeTTa commit, the code likely needs improvements from senior contributors, especially around the recursive logic.**