### PR TITLE
Add: topology_op for blend relation preservation scoring and similarity function registration

### DIFF
--- a/an_infotheoretic_approach/libs/agents/optimality_principles/main/data_sources/conceptnet_adapter.py
+++ b/an_infotheoretic_approach/libs/agents/optimality_principles/main/data_sources/conceptnet_adapter.py
@@ -37,6 +37,9 @@ class ConceptNetAdapter:
         except (requests.exceptions.RequestException, ValueError, json.JSONDecodeError):
             return 0
 
+    def get_similarity_score(self, metta: MeTTa, *args):
+        return [ValueAtom(self.get_similarity(str(args[0]), str(args[1])))]
+
     def are_antonyms(self, term1, term2):
         """Check whether two terms are antonyms."""
         edges = self.get_edges(term1, "Antonym")

--- a/an_infotheoretic_approach/libs/main.py
+++ b/an_infotheoretic_approach/libs/main.py
@@ -46,6 +46,13 @@ def grounded_atoms(metta):
         [AtomType.ATOM, AtomType.ATOM, AtomType.ATOM],
         unwrap=False
     )
+    registered_operations["get_similarity_score"] = OperationAtom(
+        "get_similarity_score",
+        lambda *args: conceptnet.get_similarity_score(metta, *args),
+        [AtomType.ATOM, AtomType.ATOM, AtomType.ATOM],
+        unwrap=False
+    )
+    
 
     return registered_operations
 

--- a/an_infotheoretic_approach/op_constraints/integration.metta
+++ b/an_infotheoretic_approach/op_constraints/integration.metta
@@ -1,5 +1,5 @@
+!(register-module! ../libs)
 ! (import! &self libs)
-! (import! &self utils:list-op-utils)
 
 
 (= (check-against-predefined-list $item $item2 $terms_antonymity $list)

--- a/an_infotheoretic_approach/op_constraints/topology.metta
+++ b/an_infotheoretic_approach/op_constraints/topology.metta
@@ -14,6 +14,7 @@
     )
 )
 )
+(= (similarity_threshold) 0.65)
 
 (= (find-similar-known-relation $rel $knowns)
    (if (== (size-atom $knowns) 0)
@@ -24,7 +25,7 @@
            ($type-similarity (get_similarity_score (car-atom $rel) (car-atom $head)))
            ($target-similarity (get_similarity_score (index-atom $rel 1) (index-atom $head 1)))
          )
-         (if (and (> $type-similarity 0.65) (> $target-similarity 0.65))
+         (if (and (> $type-similarity (similarity_threshold)) (> $target-similarity (similarity_threshold)))
             $head
              (find-similar-known-relation $rel $tail)
              ))))

--- a/an_infotheoretic_approach/op_constraints/topology.metta
+++ b/an_infotheoretic_approach/op_constraints/topology.metta
@@ -1,0 +1,117 @@
+!(register-module! ../libs)
+! (import! &self libs)
+
+(= (get-property $prop-value-pair)
+    (let ($x $y) $prop-value-pair (car-atom $y))
+)
+
+(= (relations-key-value-list ($blend_or_concept $blend_name $properties $relations)) (
+    (let*(
+        ($prop_list (cdr-atom $relations))
+        ($relation-type (map-atom $prop_list $x ((car-atom $x) (get-property $x)) ))
+    )
+        $relation-type
+    )
+)
+)
+
+(= (find-similar-known-relation $rel $knowns)
+   (if (== (size-atom $knowns) 0)
+       ()
+       (let* (
+           ($head (car-atom $knowns))
+           ($tail (cdr-atom $knowns))
+           ($type-similarity (get_similarity_score (car-atom $rel) (car-atom $head)))
+           ($target-similarity (get_similarity_score (index-atom $rel 1) (index-atom $head 1)))
+         )
+         (if (and (> $type-similarity 0.65) (> $target-similarity 0.65))
+            $head
+             (find-similar-known-relation $rel $tail)
+             ))))
+
+
+(= (normalize-relation $rel $knowns)
+   (let* (
+       ($match (find-similar-known-relation $rel $knowns))
+     )
+
+     (if (== (size-atom $match) 0)
+         (let $new $rel
+              ($new (cons-atom $new $knowns)))
+         ($match $knowns)
+         )
+    )
+)
+
+(= (list-member $item ())
+   0)
+(= (list-member $item $source)
+   (if (== $item (car-atom $source))
+       1
+       (list-member $item (cdr-atom $source))
+   )
+)
+(= (count-preserved-loop $blend-rels $source-rels $knowns)
+
+   (if (== (size-atom $blend-rels) 0)
+       0
+       (let* (
+           ($head (car-atom $blend-rels))
+           ($tail (cdr-atom $blend-rels))
+           ($norm-tuple (normalize-relation $head $knowns))
+           ($norm (car-atom $norm-tuple))
+           ($updated-knowns (cdr-atom $norm-tuple))
+           ($is-preserved (list-member $norm $source-rels))
+           ($rest-count (count-preserved-loop $tail $source-rels (car-atom $updated-knowns)))
+
+         )
+         (+ $is-preserved $rest-count)
+         )
+        )
+)
+
+
+(= (topology_op $blend $concept1 $concept2 )
+    (let*(
+        ($blend-prop-list (properties-list $blend))
+        ($concept1-relations-list (relations-key-value-list $concept1))
+        ($concept2-relations-list (relations-key-value-list $concept2))
+        ($concept1-relations-inner (car-atom $concept1-relations-list))
+        ($concept2-relations-inner (car-atom $concept2-relations-list))
+        ($union-relations (union-atom $concept1-relations-inner $concept2-relations-inner))
+        ($source-relations (unique-atom $union-relations))
+        ($source-relations-size (size-atom $source-relations))
+        ($blend-relations-list (relations-key-value-list $blend))
+        ($preserved-count (count-preserved-loop (car-atom $blend-relations-list) $source-relations ()))
+
+        ($source-relations-size-decimal (+ 0.00000000000000001 $source-relations-size))
+        ($preservation-score (/ $preserved-count $source-relations-size-decimal)
+        )
+    )(
+        $preservation-score
+    )
+    )
+)
+
+(= (good_blend)
+    (Blend amphibious_vehicle 
+    (Properties  (metal (car)) (floats (boat)) (waterproof))
+    (Relations (UsedFor (transportation 1.0)) (HasPartd (engine 0.8)))
+    )
+)
+
+(= (concept1)
+    (Concept car 
+    (Properties  (metal (car)) (hasWheels (car)))
+    (Relations (UsedFor (transportation 0.9)) (HasPart (engine 0.8)))
+    )
+)
+
+(= (concept2)
+    (Concept boat 
+    (Properties  (floats (boat)) (waterproof (boat)))
+    (Relations (UsedFor (transportation 0.9)) (UsedFor (recreation 0.7)))
+    )
+)
+
+! (topology_op (good_blend) (concept1) (concept2))


### PR DESCRIPTION
This PR introduces a new `topology_op` operation that evaluates how well a conceptual blend preserves the relations from its source concepts. It calculates a preservation score based on normalized relation similarity using a thresholded comparison.

Key additions:

* `topology_op` function for computing relation preservation score.
* `normalize-relation` and `find-similar-known-relation` logic to match similar relations using semantic similarity.
* `count-preserved-loop` function to iterate and compute preserved relations.
* Registration of a new grounded atom `get_similarity_score` in `main.py`.
* `get_similarity_score` implementation using ConceptNet-based similarity.

### **Testing**

Tested with a `good_blend` example combining `car` and `boat`, verifying relation preservation score aligns with expectations.


### Notes

* Converting $source-relations-size to decimal needs a better way
* This topology optimality score is pluggable on info-theoretic.metta.
* **This is my second MeTTa commit, the code likely needs improvements from seniors**