### PR TITLE
feat: Implement unpacking optimality principle evaluation via provenance and semantic similarity

### DIFF
--- a/an_infotheoretic_approach/libs/main.py
+++ b/an_infotheoretic_approach/libs/main.py
@@ -52,6 +52,19 @@ def grounded_atoms(metta):
         [AtomType.ATOM, AtomType.ATOM, AtomType.ATOM],
         unwrap=False
     )
+
+    registered_operations["get_expand_provenance"] = OperationAtom(
+        "get_expand_provenance",
+        lambda *args: conceptnet.get_expand_provenance(metta, *args),
+        [AtomType.ATOM, AtomType.ATOM],
+        unwrap=False
+    )
+    registered_operations["are_related"] = OperationAtom(
+        "are_related",
+        lambda *args: conceptnet.are_related(metta, *args),
+        [AtomType.ATOM, AtomType.ATOM, AtomType.ATOM],
+        unwrap=False
+    )
     
 
     return registered_operations

--- a/an_infotheoretic_approach/op_constraints/unpacking.metta
+++ b/an_infotheoretic_approach/op_constraints/unpacking.metta
@@ -1,0 +1,113 @@
+!(register-module! ../libs)
+! (import! &self libs)
+
+(= (properties-list (Blend $blend_name $properties $relations)) (
+    let $prop_list $properties (cdr-atom $prop_list)
+    )
+)
+
+(= (blend-name (Blend $blend_name $properties $relations)) 
+$blend_name
+)
+
+
+(= (evaluate-property ($prop-name $provenance-list) $blend-name)
+   (if (== (size-atom $provenance-list) 0)
+       0.0
+       (let* (
+            ($expanded_provenance 
+                (if (expansion-enabled) 
+                    (get_expand_provenance $provenance-list)
+                    ($provenance-list)
+                ))
+           ($strength (provenance-strength $prop-name $expanded_provenance $blend-name))
+           
+       )
+        $strength
+       )
+   )
+)
+
+(= (calculate-source-strength $prop-name $source-expr $blend-name)
+    (let* (
+        ($source-word (car-atom $source-expr))
+    )
+        (if (== $source-word $blend-name)
+            1.0
+            (let* (
+                ($similarity (get_similarity_score $prop-name $source-word))
+                ($is-related (are_related $prop-name $source-word))
+            )
+                (if $is-related
+                     (max-atom ($similarity 0.8))
+                     $similarity)
+            )
+        )
+    )
+)
+
+
+(= (max-of-two $a $b)(if (> $a $b) $a $b))
+(= (max-in-list ($x)) $x)
+(= (max-in-list $list) (max-of-two (car-atom $list) (max-in-list (cdr-atom $list))))
+
+
+
+(= (sum ()) 0)
+(= (sum $lst)
+   (+ (car-atom $lst) (sum (cdr-atom $lst)))
+)
+
+(= (provenance-strength $prop-name $provenance-list $blend-name)
+    (let* (
+        ($scores (map-atom $provenance-list
+            $source-expr
+            (calculate-source-strength $prop-name $source-expr $blend-name)
+        ))
+
+        ($max-score (max-in-list $scores))
+
+        ($min-similarity (min-similarity))
+        ($max-strength (
+            if (> $max-score $min-similarity) 
+                    $max-score
+                    0.0
+            ))
+
+    )
+    $max-strength
+    )
+)
+
+
+(= (unpacking_op $good_blend )
+    (let*(
+        ($props (properties-list $good_blend))
+        ($blend-name (blend-name $good_blend))
+        ($scores (map-atom $props
+                    $p
+                    (
+                        evaluate-property $p $blend-name
+                    )
+                )
+        )
+        ($total_score (sum $scores))
+   )
+   (
+    if (> (size-atom $props) 0) (/ $total_score (size-atom $props)) 0.0
+   )
+   )
+)
+
+(= (good_blend)
+    (Blend amphibious_vehicle 
+    (Properties  (metal (car)) (floats (boat)) (waterproof ()) )
+    (Relations (UsedFor (transportation 1.0)) (HasPartd (engine 0.8)))
+    )
+)
+
+
+(= (expansion-enabled) True )
+(= (min-similarity) 0.65 )
+
+! (unpacking_op (good_blend))


### PR DESCRIPTION
This PR adds a MeTTa implementation of the unpacking optimality principle for conceptual blending. It uses grounded operations from ConceptNet to assess how well a blend satisfies inherited properties from source concepts. The process involves:

* Extracting and evaluating properties using provenance paths.
* Computing semantic similarity and relational strength between source and blend.
* Aggregating normalized scores to yield a final optimality score.

## Additions
* Introduced `unpacking_op` to compute unpacking optimality score of a blend.
* Added helper functions: `evaluate-property`, `calculate-source-strength`, and `provenance-strength`.
* Integrated grounded atoms: `get_expand_provenance` and `are_related`.
* Enabled provenance expansion and min similarity threshold settings.
* Added a test blend `good_blend` and invoked evaluation at the end.
