### PR TITLE
feat: Add metonymy based compression optimality principle

### DIFF
--- a/an_infotheoretic_approach/libs/agents/optimality_principles/main/data_sources/conceptnet_adapter.py
+++ b/an_infotheoretic_approach/libs/agents/optimality_principles/main/data_sources/conceptnet_adapter.py
@@ -24,6 +24,10 @@ class ConceptNetAdapter:
         except (requests.exceptions.RequestException, ValueError, json.JSONDecodeError):
             return []
 
+    def is_abbreviation(self, metta: MeTTa, *args):
+        return [ValueAtom(any(edge["rel"]["label"] in ["Abbreviation", "Acronym"]
+               for edge in self.get_edges(str(args[0]), "FormOf")))]
+
     def get_expand_provenance(self, metta: MeTTa, *args):
         # (car) or (car boat)
         input_expr = args[0]
@@ -98,9 +102,15 @@ class ConceptNetAdapter:
                 self.is_related(term, context, "LocatedNear") or
                 self.is_related(term, context, "SymbolOf"))
 
+    def is_relation_metonymy(self, metta: MeTTa, *args):
+        return [ValueAtom(self.is_metonymy(str(args[0]), str(args[1])))]
+
     def is_part_of(self, part, whole):
         """Determine if one concept is part of another."""
         return self.is_related(part, whole, "PartOf")
+
+    def is_relation_part_of(self, metta: MeTTa, *args):
+        return [ValueAtom(self.is_part_of(str(args[0]), str(args[1])))]
 
     def is_justified(self, property, context):
         """Determine whether a property is justified in the context of a concept."""

--- a/an_infotheoretic_approach/libs/main.py
+++ b/an_infotheoretic_approach/libs/main.py
@@ -65,6 +65,24 @@ def grounded_atoms(metta):
         [AtomType.ATOM, AtomType.ATOM, AtomType.ATOM],
         unwrap=False
     )
+    registered_operations["is_abbreviation"] = OperationAtom(
+        "is_abbreviation",
+        lambda *args: conceptnet.is_abbreviation(metta, *args),
+        [AtomType.ATOM, AtomType.ATOM],
+        unwrap=False
+    )
+    registered_operations["is_relation_metonymy"] = OperationAtom(
+        "is_relation_metonymy",
+        lambda *args: conceptnet.is_relation_metonymy(metta, *args),
+        [AtomType.ATOM, AtomType.ATOM, AtomType.ATOM],
+        unwrap=False
+    )
+    registered_operations["is_relation_part_of"] = OperationAtom(
+        "is_relation_part_of",
+        lambda *args: conceptnet.is_relation_part_of(metta, *args),
+        [AtomType.ATOM, AtomType.ATOM, AtomType.ATOM],
+        unwrap=False
+    )
     
 
     return registered_operations

--- a/an_infotheoretic_approach/op_constraints/common-utils.metta
+++ b/an_infotheoretic_approach/op_constraints/common-utils.metta
@@ -1,0 +1,36 @@
+
+(= (good_blend)
+    (Blend amphibious_vehicle 
+    (Properties  (metal (car)) (floats (boat)) (waterproof))
+    (Relations (UsedFor (transportation 1.0)) (Short_HasPart (engine 0.8)))
+    )
+)
+
+(= (detect-abbreviations) True )
+
+(= (detect-characteristic-parts) True )
+
+(= (get-property $prop-value-pair)
+    (let ($x $y) $prop-value-pair $x)
+)
+
+(= (properties-list (Blend $blend_name $properties $relations)) (
+    let $prop_list $properties (cdr-atom $prop_list)
+    )
+)
+
+(= (relations-key-value-list ($blend_or_concept $blend_name $properties $relations)) (
+    (let*(
+        ($prop_list (cdr-atom $relations))
+        ($relation-type (map-atom $prop_list $x ((car-atom $x) (get-property (index-atom $x 1))) ))
+    )
+        $relation-type
+    )
+)
+)
+
+(: to-float (-> Number Number))
+(= (to-float $x) (+ $x 0.0))
+
+
+(= (blend-name ($blend_or_concept $blend_name $properties $relations)) $blend_name )

--- a/an_infotheoretic_approach/op_constraints/metonymy.metta
+++ b/an_infotheoretic_approach/op_constraints/metonymy.metta
@@ -1,0 +1,113 @@
+!(register-module! ../libs)
+! (import! &self libs)
+! (import! &self common-utils)
+
+(= (check-indicators-recursive $rel-type-str $indicators)
+    (if (< (size-atom $indicators) 1)
+        False
+        (let* (($current-indicator (car-atom $indicators))
+               ($remaining-indicators (cdr-atom $indicators)))
+            (
+                if (== $rel-type-str $current-indicator)
+                    True
+                    (check-indicators-recursive $rel-type-str $remaining-indicators)
+            )
+        )
+    )
+)
+
+(= (compression-indicators) (Syn Metonym Short_HasPart Abbr Contraction))
+
+(= (is-compressed $relation)
+    (let* (($rel-type-str (car-atom $relation))
+           ($indicators (compression-indicators)))
+        (check-indicators-recursive $rel-type-str $indicators)
+        
+    )
+)
+
+
+(= (is-target-in-properties-name $target $blend-properties)
+    (if (< (size-atom $blend-properties) 1)
+        False
+        (let* (($current-rel (car-atom $blend-properties))
+               ($remaining-rels (cdr-atom $blend-properties))
+
+               )
+
+            (
+                if (== $target (car-atom $current-rel))
+                    True
+                    (is-target-in-properties-name $target $remaining-rels)
+            )
+        )
+    )
+)
+
+(= (is-characteristic-part $relation $blend-properties $bled-name) 
+(let* (
+        ($is-target-in-rel (is-target-in-properties-name (index-atom $relation 1) $blend-properties))
+            )
+            (if (== $is-target-in-rel True)
+                True
+                (is_relation_part_of (index-atom $relation 1) $bled-name)
+            )
+    )
+)
+
+(= (is-semantically-compressed $relation $blend-properties $blend-name $detect-abbreviations $detect-characteristic-parts) 
+
+    (let* (
+        ($is-abbrev (is_abbreviation (car-atom $relation)))
+        ($is-metonymy (is_relation_metonymy (car-atom $relation) (index-atom $relation 1)))
+        
+        )
+        (if (and $detect-abbreviations $is-abbrev)
+            True
+            (if (== $is-metonymy True)
+                True
+                (if (and $detect-characteristic-parts (is-characteristic-part $relation $blend-properties $blend-name))
+                    True
+                    False
+                )
+            )
+        )
+    )
+)
+
+
+(= (count-compressed-relations $relations $blend-properties $blend-name $acc)
+    (if (< (size-atom $relations) 1)
+        $acc
+        (let* (($current-rel (car-atom $relations))
+               ($remaining-rels (cdr-atom $relations))
+               ($is-compressed (is-compressed $current-rel))
+               ($is-semantically-compressed (is-semantically-compressed $current-rel $blend-properties $blend-name (detect-abbreviations) (detect-characteristic-parts)))
+               ($new-acc (if (or $is-compressed $is-semantically-compressed)
+                           (+ $acc 1)
+                             $acc))
+                )
+            (count-compressed-relations $remaining-rels $blend-properties $blend-name $new-acc)
+        )
+    )
+)
+(= (metonymy_op $blend)
+  (let* (
+    ($blend-relations (relations-key-value-list $blend))
+    ($blend-relations-inner (car-atom $blend-relations))
+    ($total-relations (size-atom $blend-relations-inner))    
+    ($blend-name (blend-name (good_blend)))
+    ($blend-properties (properties-list (good_blend)))
+    ($compressed-count (count-compressed-relations $blend-relations-inner $blend-properties $blend-name 0))
+    ($compressed-count-float (to-float $compressed-count))
+  )
+    (
+        if (> $total-relations 0)
+            (/ $compressed-count-float $total-relations)
+            0.0
+    )
+  )
+)
+
+
+! (metonymy_op (good_blend))


### PR DESCRIPTION
This PR introduces the **metonymy optimality principle** for evaluating semantic compression in concept blends. It calculates a normalized compression score based on both syntactic and semantic indicators.

### Key Features:

* **Syntactic Compression**: `Short_HasPart`, `Syn`, `Abbr`, `Metonym`, `Contraction` relations are considered compressive.
* **Semantic Compression**:

  * Detects abbreviations via `is_abbreviation`
  * Detects metonymic relations via `is_relation_metonymy`
  * Identifies characteristic parts with `is_relation_part_of`
* **Recursive Evaluation**: Traverses blend relation list to count compressed ones using `count-compressed-relations`.
* **Main Operator**: `metonymy_op` returns the compression ratio for a given blend.

### Utilities Added:

* `check-indicators-recursive`: checks if a relation type matches known compression indicators.
* `is-semantically-compressed`: checks semantic compressiveness using configurable detection flags.
* `properties-list`, `relations-key-value-list`, `blend-name`, and `to-float` helpers for processing blend structures.

### Example:
```metta metonymy.metta```
Evaluating `good_blend` yields a metonymy compression score based on the number of compressed relations out of total relations.

### Note
* `common-utils.metta`: added to collect all common optimality principle utils in one place
* `is_abbreviation`, `is_relation_metonymy`, `is_relation_part_of` grounded atoms registered to get data from ConceptNetAdapter api