### PR TITLE
Add prerequisites section to README with Python/WSL2 requirements

### DIFF
--- a/an_infotheoretic_approach/README.md
+++ b/an_infotheoretic_approach/README.md
@@ -10,6 +10,10 @@ The **Information-Theoretic Conceptual** Blending system enhances concept synthe
 
 ## Setup and Run
 
+### Prerequisities
+
+- **For Windows Users**: The hyperon package version (0.2.4) required by this project doesn't have pre-compiled binaries for Windows. Therefore,you must use the Windows Subsystem for Linux(WSL) 2 to run this project.
+- **Python Version**: This project requires Python 3.8 or newer (compatible up to Python 3.13).
 ### 1. Clone the repository and navigate to the folder
 ```bash
 git clone https://github.com/iCog-Labs-Dev/conceptBlending.git


### PR DESCRIPTION
## Summary of Changes

- Created the **Prerequisites** section in the `README` of the **an_infotheoretic_approach** folder to clarify environment requirements:

     - Added a note for **Windows** users about needing WSL2, since the required **hyperon package (v0.2.4)** lacks precompiled Windows binaries.

    - Specified that the project requires Python 3.8–3.13 for compatibility.

This improves setup guidance and prevents confusion for new contributors or users.